### PR TITLE
Resolvido exercicio extra 3

### DIFF
--- a/cypress/integration/CAC-TAT.specs.js
+++ b/cypress/integration/CAC-TAT.specs.js
@@ -59,4 +59,10 @@ describe('Central de Atendimento ao Cliente TAT', function(){
     cy.get('.error').should('be.visible') 
     })
     
+    it('Campo telefone continua vazio quando preenchido com valor não-numérico', () =>{
+
+        cy.get('#phone').should('be.visible')
+        .type('abcdefghij')
+        .should('have.value', '');
+    })
 })


### PR DESCRIPTION
Exercício extra 3
- Visto que o campo de telefone só aceita números, crie um teste para validar que, se um valor não-numérico for digitado, seu valor continuará vazio.

👨‍🏫 Pra te ajudar com a verificação do valor de um input, recomendo a leitura do [seguinte conteúdo](https://docs.cypress.io/faq/questions/using-cypress-faq#How-do-I-get-an-input-s-value), direto da documentação oficial do Cypress. O primeiro exemplo deve ser o suficiente.
