### PR TITLE
Resolvendo exercicio extra 4

### DIFF
--- a/cypress/integration/CAC-TAT.specs.js
+++ b/cypress/integration/CAC-TAT.specs.js
@@ -1,34 +1,34 @@
 /// <reference types='Cypress' />
 
-describe('Central de Atendimento ao Cliente TAT', function(){
+describe('Central de Atendimento ao Cliente TAT', function () {
 
     beforeEach(() => {
         cy.visit('./src/index.html');
     });
 
-    it('Verifica o título da aplicação', function(){
+    it('Verifica o título da aplicação', function () {
         cy.title().should('be.equal', 'Central de Atendimento ao Cliente TAT');
     })
 
     it('Preenche os campos obrigatórios e envia o formulário', () => {
         const longText = "Teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste "
-        
+
         cy.get('#firstName').should('be.visible')
-        .type('Bruno')
-        .should('have.value', 'Bruno');
+            .type('Bruno')
+            .should('have.value', 'Bruno');
 
         cy.get('#lastName').should('be.visible')
-        .type('Faria')
-        .should('have.value', 'Faria');
+            .type('Faria')
+            .should('have.value', 'Faria');
 
         cy.get('#email').should('be.visible')
-        .type('brunoluizb@hotmail.com')
-        .should('have.value', 'brunoluizb@hotmail.com');
+            .type('brunoluizb@hotmail.com')
+            .should('have.value', 'brunoluizb@hotmail.com');
 
         cy.get('#open-text-area').should('be.visible')
-        .type(longText, {delay: 0})
-        .should('have.value', longText);        
-        
+            .type(longText, { delay: 0 })
+            .should('have.value', longText);
+
         cy.get('button[type="submit"]').click();
 
         cy.get('.success').should('be.visible')
@@ -36,33 +36,62 @@ describe('Central de Atendimento ao Cliente TAT', function(){
     });
 
     it('Exibe mensagem de erro ao submeter o formulário com um email com formatação inválida', () => {
-    const longText = "Teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste "
-    
-    cy.get('#firstName').should('be.visible')
-    .type('Bruno')
-    .should('have.value', 'Bruno');
+        const longText = "Teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste "
 
-    cy.get('#lastName').should('be.visible')
-    .type('Faria')
-    .should('have.value', 'Faria');
+        cy.get('#firstName').should('be.visible')
+            .type('Bruno')
+            .should('have.value', 'Bruno');
 
-    cy.get('#email').should('be.visible')
-    .type('brunoluizbhotmail.com')
-    .should('have.value', 'brunoluizbhotmail.com');
+        cy.get('#lastName').should('be.visible')
+            .type('Faria')
+            .should('have.value', 'Faria');
 
-    cy.get('#open-text-area').should('be.visible')
-    .type(longText, {delay: 0})
-    .should('have.value', longText);        
-    
-    cy.get('button[type="submit"]').click();
+        cy.get('#email').should('be.visible')
+            .type('brunoluizbhotmail.com')
+            .should('have.value', 'brunoluizbhotmail.com');
 
-    cy.get('.error').should('be.visible') 
+        cy.get('#open-text-area').should('be.visible')
+            .type(longText, { delay: 0 })
+            .should('have.value', longText);
+
+        cy.get('button[type="submit"]').click();
+
+        cy.get('.error').should('be.visible')
     })
-    
-    it('Campo telefone continua vazio quando preenchido com valor não-numérico', () =>{
+
+    it('Campo telefone continua vazio quando preenchido com valor não-numérico', () => {
 
         cy.get('#phone').should('be.visible')
-        .type('abcdefghij')
-        .should('have.value', '');
+            .type('abcdefghij')
+            .should('have.value', '');
+    })
+
+    it('Exibe mensagem de erro quando o telefone se torna obrigatório mas não é preenchido antes do envio do formulário', () => {
+        const longText = "Teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste "
+
+        cy.get('#firstName').should('be.visible')
+            .type('Bruno')
+            .should('have.value', 'Bruno');
+
+        cy.get('#lastName').should('be.visible')
+            .type('Faria')
+            .should('have.value', 'Faria');
+
+        cy.get('#email').should('be.visible')
+            .type('brunoluizb@hotmail.com')
+            .should('have.value', 'brunoluizb@hotmail.com');
+        
+        cy.get('#phone')
+            .should('have.value', '');
+
+        cy.get('#phone-checkbox').check();
+
+        cy.get('#open-text-area').should('be.visible')
+            .type(longText, { delay: 0 })
+            .should('have.value', longText);
+
+        cy.get('button[type="submit"]').click();
+
+        cy.get('.error').should('be.visible')
     })
 })


### PR DESCRIPTION
Exercício extra 4
Crie um teste chamado exibe mensagem de erro quando o telefone se torna obrigatório mas não é preenchido antes do envio do formulário
Tal teste deve verificar que uma mensagem é exibida em um elemento com a classe error
Por fim, execute o novo teste no Test Runner, e quando o mesmo estiver passando, siga adiante para o próximo exercício