### PR TITLE
Resolvendo exercicio extra 5

### DIFF
--- a/cypress/integration/CAC-TAT.specs.js
+++ b/cypress/integration/CAC-TAT.specs.js
@@ -80,7 +80,7 @@ describe('Central de Atendimento ao Cliente TAT', function () {
         cy.get('#email').should('be.visible')
             .type('brunoluizb@hotmail.com')
             .should('have.value', 'brunoluizb@hotmail.com');
-        
+
         cy.get('#phone')
             .should('have.value', '');
 
@@ -93,5 +93,34 @@ describe('Central de Atendimento ao Cliente TAT', function () {
         cy.get('button[type="submit"]').click();
 
         cy.get('.error').should('be.visible')
+    })
+
+    it.only('Preenche e limpa os campos de nome, sobrenome, email e telefone', () => {
+
+        const longText = "Teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste "
+
+        cy.get('#firstName')
+            .type('Bruno')
+            .should('have.value', 'Bruno')
+            .clear()
+            .should('have.value', '');
+
+        cy.get('#lastName')
+            .type('Faria')
+            .should('have.value', 'Faria')
+            .clear()
+            .should('have.value', '');
+
+        cy.get('#email')
+            .type('brunoluizb@hotmail.com')
+            .should('have.value', 'brunoluizb@hotmail.com')
+            .clear()
+            .should('have.text', '');
+
+        cy.get('#phone')
+            .type('12345678910')
+            .should('have.value', '12345678910')
+            .clear()
+            .should('have.text', '');
     })
 })


### PR DESCRIPTION
Exercício extra 5
Uma funcionalidade que pode ser usada em conjunto com comando o .type(), é o [.clear()](https://on.cypress.io/clear), o qual limpa um campo, para posterior digitação, por exemplo.

Portanto, crie um teste chamado preenche e limpa os campos nome, sobrenome, email e telefone
Tal teste deve verificar o valor (value) após a digitação (.type(...).should('have.value', 'valor-aqui')), e após a limpeza do campo (.clear().should('have.value', ''))
Por fim, execute o novo teste no Test Runner, e quando o mesmo estiver passando, siga adiante para o próximo exercício