### PR TITLE
Resolvendo exercicio extra 6

### DIFF
--- a/cypress/integration/CAC-TAT.specs.js
+++ b/cypress/integration/CAC-TAT.specs.js
@@ -95,7 +95,7 @@ describe('Central de Atendimento ao Cliente TAT', function () {
         cy.get('.error').should('be.visible')
     })
 
-    it.only('Preenche e limpa os campos de nome, sobrenome, email e telefone', () => {
+    it('Preenche e limpa os campos de nome, sobrenome, email e telefone', () => {
 
         const longText = "Teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste, teste "
 
@@ -122,5 +122,12 @@ describe('Central de Atendimento ao Cliente TAT', function () {
             .should('have.value', '12345678910')
             .clear()
             .should('have.text', '');
+    })
+
+    it('Exibe mensagem de erro ao submeter o formulario sem preencher os campos obrigatorios', () => {
+        
+        cy.get('button[type="submit"]').click();
+
+        cy.get('.error').should('be.visible')
     })
 })


### PR DESCRIPTION
Exercício extra 6
Crie um novo teste chamado exibe mensagem de erro ao submeter o formulário sem preencher os campos obrigatórios.
O teste deve simplesmente acessar a aplicação e clicar no botão Enviar
Tal teste deve verificar que uma mensagem é exibida em um elemento com a classe error
Por fim, execute o novo teste no Test Runner, e quando o mesmo estiver passando, siga adiante para o próximo exercício