### PR TITLE
Resolvendo exercicio extra 8

### DIFF
--- a/cypress/integration/CAC-TAT.specs.js
+++ b/cypress/integration/CAC-TAT.specs.js
@@ -29,7 +29,7 @@ describe('Central de Atendimento ao Cliente TAT', function () {
             .type(longText, { delay: 0 })
             .should('have.value', longText);
 
-        cy.get('button[type="submit"]').click();
+        cy.contains('button', 'Enviar').click();
 
         cy.get('.success').should('be.visible')
 
@@ -54,7 +54,7 @@ describe('Central de Atendimento ao Cliente TAT', function () {
             .type(longText, { delay: 0 })
             .should('have.value', longText);
 
-        cy.get('button[type="submit"]').click();
+        cy.contains('button', 'Enviar').click();
 
         cy.get('.error').should('be.visible')
     })
@@ -90,7 +90,7 @@ describe('Central de Atendimento ao Cliente TAT', function () {
             .type(longText, { delay: 0 })
             .should('have.value', longText);
 
-        cy.get('button[type="submit"]').click();
+        cy.contains('button', 'Enviar').click();
 
         cy.get('.error').should('be.visible')
     })
@@ -126,7 +126,7 @@ describe('Central de Atendimento ao Cliente TAT', function () {
 
     it('Exibe mensagem de erro ao submeter o formulario sem preencher os campos obrigatorios', () => {
         
-        cy.get('button[type="submit"]').click();
+        cy.contains('button', 'Enviar').click();
 
         cy.get('.error').should('be.visible')
     })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -15,5 +15,5 @@ Cypress.Commands.add('fillMandatoryFieldsAndSubmit', (firstName, lastName, email
         .type(openTextArea, { delay: 0 })
         .should('have.value', openTextArea);
 
-    cy.get('button[type="submit"]').click();
+    cy.contains('button', 'Enviar').click();
 })


### PR DESCRIPTION
Exercício extra 8
Outra forma de identificar elementos (para, por exemplo, clicar neles após sua definição) é o uso da funcionalidade [cy.contains()](https://on.cypress.io/contains).

Com o cy.contains(), além de um seletor CSS, você pode passar como segundo argumento um texto, o qual deve estar contido no elemento o qual você deseja identificar.

Algo como o seguinte: cy.contains('a', 'Clique aqui!').

Teu exercíco é alterar todos os locais onde identificamos o botão para posterior clique, onde em vez de identificarmos tal elemento com o cy.get(), iremos usar o cy.contains().

👨‍🏫 Lembre-se de executar todos os testes após a alteração, para garantir que suas mudanças não quebraram nada.

Conteúdos sugeridos
Nos conteúdos listados abaixo, faço diferentes usos do comando .type().

[Como preencher e submeter formulários com Cypress](https://talkingabouttesting.com/2021/02/05/como-preencher-e-submeter-formularios-com-cypress/)
[Como proteger dados sensíveis com Cypress](https://talkingabouttesting.com/2021/02/09/como-proteger-dados-sensiveis-com-cypress/)
[3 maneiras de testar funcionalidades de busca com Cypress.io](https://youtu.be/bqz7sv-LgrM)
[Testando busca com auto-complete usando Cypress](https://youtu.be/3qUq0XkPwts)
[Como testar campos de data com Cypress](https://youtu.be/wiDOdfmuR2o)